### PR TITLE
Updated Chrome secure column name

### DIFF
--- a/lib/cookie_extractor/chrome_cookie_extractor.rb
+++ b/lib/cookie_extractor/chrome_cookie_extractor.rb
@@ -16,7 +16,7 @@ module CookieExtractor
         result << [ row['host_key'],
           true_false_word(is_domain_wide(row['host_key'])),
           row['path'],
-          true_false_word(row['secure']),
+          true_false_word(row['is_secure']),
           row['expires_utc'],
           row['name'],
           row['value']

--- a/lib/cookie_extractor/version.rb
+++ b/lib/cookie_extractor/version.rb
@@ -1,3 +1,3 @@
 module CookieExtractor
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Chrome seems to have changed the `secure` column to `is_secure` at some point. This simply uses the new column name.

Tested with Chrome 88.0.4324.150.