### PR TITLE
Several improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,36 @@
 PATH
   remote: .
   specs:
-    cookie_extractor (0.0.1)
-      sqlite3-ruby
+    cookie_extractor (0.2.0)
+      sqlite3 (~> 2.9)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
-    rspec (2.8.0)
-      rspec-core (~> 2.8.0)
-      rspec-expectations (~> 2.8.0)
-      rspec-mocks (~> 2.8.0)
-    rspec-core (2.8.0)
-    rspec-expectations (2.8.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.8.0)
-    sqlite3 (1.3.5)
-    sqlite3-ruby (1.3.3)
-      sqlite3 (>= 1.3.3)
+    diff-lcs (1.6.2)
+    mini_portile2 (2.8.9)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    sqlite3 (2.9.6)
+      mini_portile2 (~> 2.8.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   cookie_extractor!
-  rspec
+  rspec (~> 3.13)
+
+BUNDLED WITH
+  4.0.15

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/bin/cookie_extractor
+++ b/bin/cookie_extractor
@@ -35,7 +35,7 @@ begin
       usage
     else
       filename = ARGV.first
-      abort "Error: #{filename} does not exist" unless File.exists?(filename)
+      abort "Error: #{filename} does not exist" unless File.exist?(filename)
       CookieExtractor::BrowserDetector.new_extractor(filename)
     end
   puts extractor.extract.join("\n")

--- a/bin/cookie_extractor
+++ b/bin/cookie_extractor
@@ -19,7 +19,7 @@ begin
       begin
         CookieExtractor::BrowserDetector.guess()
       rescue CookieExtractor::NoCookieFileFoundException
-        abort "Error: we couldn't find any supported broswer's cookies"
+        abort "Error: we couldn't find any supported browser's cookies"
       end
     when '--browser', '-b'
       browser = ARGV[1]

--- a/cookie_extractor.gemspec
+++ b/cookie_extractor.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rspec", "~> 2.8"
-  s.add_runtime_dependency "sqlite3-ruby", "~> 1.3"
+  s.add_development_dependency "rspec", "~> 3.13"
+  s.add_runtime_dependency "sqlite3", "~> 2.9"
 end

--- a/lib/cookie_extractor/browser_detector.rb
+++ b/lib/cookie_extractor/browser_detector.rb
@@ -4,18 +4,15 @@ module CookieExtractor
   class NoCookieFileFoundException < Exception; end
 
   class BrowserDetector
-    COOKIE_LOCATIONS = {
-      "chrome" => "~/.config/google-chrome/Default/Cookies",
-      "chromium" => "~/.config/chromium/Default/Cookies",
-      "firefox" => "~/.mozilla/firefox/*.default/cookies.sqlite"
-    }
+    CHROMIUM_BROWSERS = %w[chrome chromium].freeze
+    SUPPORTED_BROWSERS = (CHROMIUM_BROWSERS + %w[firefox]).freeze
 
     # Returns the extractor of the most recently used browser's cookies
     #   or raise NoCookieFileFoundException if there are no cookies
     def self.guess
-      most_recently_used_detected_browsers.each { |browser, path|
+      most_recently_used_detected_browsers.each { |path|
         begin
-          extractor = self.browser_extractor(browser)
+          extractor = self.browser_extractor(nil, path)
         rescue BrowserNotDetectedException, NoCookieFileFoundException
           # better try the next one...
         else
@@ -27,9 +24,9 @@ module CookieExtractor
     end
 
     # Open a browser's cookie file using intelligent guesswork
-    def self.browser_extractor(browser)
-      raise InvalidBrowserNameException, "Browser must be one of: #{self.supported_browsers.join(', ')}" unless self.supported_browsers.include?(browser)
-      paths = Dir.glob(File.expand_path(COOKIE_LOCATIONS[browser]))
+    def self.browser_extractor(browser, path = nil)
+      raise InvalidBrowserNameException, "Browser must be one of: #{self.supported_browsers.join(', ')}" unless browser.nil? || self.supported_browsers.include?(browser)
+      paths = path.nil? ? most_recently_used(cookie_locations(browser)) : [path]
       if paths.length < 1 or not File.exist?(paths.first)
         raise NoCookieFileFoundException, "File #{paths.first} does not exist!"
       end
@@ -46,7 +43,7 @@ module CookieExtractor
     end
 
     def self.supported_browsers
-      COOKIE_LOCATIONS.keys
+      SUPPORTED_BROWSERS
     end
 
     def self.detect_browser(db_filename)
@@ -65,11 +62,27 @@ module CookieExtractor
       db.table_info(table_name).size > 0
     end
 
+    def self.cookie_locations(browser = nil)
+      browsers = browser.nil? ? supported_browsers : [browser]
+      locations = []
+      locations << "~/.config/google-chrome/Default/Cookies" if browsers.include?("chrome")
+      locations << "~/.config/chromium/Default/Cookies" if browsers.include?("chromium")
+      if browsers.include?("firefox")
+        locations << "~/.mozilla/firefox/*.*default*/cookies.sqlite"
+        locations << "~/.mozilla/firefox/*.Profile*/cookies.sqlite"
+      end
+      locations
+    end
+
     def self.most_recently_used_detected_browsers
-      COOKIE_LOCATIONS.select { |browser, path|
-        Dir.glob(File.expand_path(path)).any?
-      }.sort_by { |browser, path|
-        File.mtime(Dir.glob(File.expand_path(path)).first)
+      most_recently_used(cookie_locations)
+    end
+
+    def self.most_recently_used(paths)
+      paths.flat_map { |path|
+        Dir.glob(File.expand_path(path))
+      }.sort_by { |path|
+        File.mtime(path)
       }.reverse
     end
 

--- a/lib/cookie_extractor/browser_detector.rb
+++ b/lib/cookie_extractor/browser_detector.rb
@@ -30,7 +30,7 @@ module CookieExtractor
     def self.browser_extractor(browser)
       raise InvalidBrowserNameException, "Browser must be one of: #{self.supported_browsers.join(', ')}" unless self.supported_browsers.include?(browser)
       paths = Dir.glob(File.expand_path(COOKIE_LOCATIONS[browser]))
-      if paths.length < 1 or not File.exists?(paths.first)
+      if paths.length < 1 or not File.exist?(paths.first)
         raise NoCookieFileFoundException, "File #{paths.first} does not exist!"
       end
       self.new_extractor(paths.first)

--- a/lib/cookie_extractor/chrome_cookie_extractor.rb
+++ b/lib/cookie_extractor/chrome_cookie_extractor.rb
@@ -8,20 +8,15 @@ module CookieExtractor
       @cookie_file = cookie_file
     end
 
-    def extract
+    def extract(format: :netscape, domain: nil)
       db = SQLite3::Database.new @cookie_file
       db.results_as_hash = true
       result = []
       db.execute("SELECT * FROM cookies") do |row|
+        next unless domain.nil? || cookie_applies?(row['host_key'], domain)
+
         secure = row.key?('is_secure') ? row['is_secure'] : row['secure']
-        result << [ row['host_key'],
-          true_false_word(is_domain_wide(row['host_key'])),
-          row['path'],
-          true_false_word(secure),
-          row['expires_utc'],
-          row['name'],
-          row['value']
-        ].join("\t")
+        result << cookie_line(row['host_key'], row['path'], secure, row['expires_utc'], row['name'], row['value'], format: format)
       end
       db.close
       result

--- a/lib/cookie_extractor/chrome_cookie_extractor.rb
+++ b/lib/cookie_extractor/chrome_cookie_extractor.rb
@@ -13,10 +13,11 @@ module CookieExtractor
       db.results_as_hash = true
       result = []
       db.execute("SELECT * FROM cookies") do |row|
+        secure = row.key?('is_secure') ? row['is_secure'] : row['secure']
         result << [ row['host_key'],
           true_false_word(is_domain_wide(row['host_key'])),
           row['path'],
-          true_false_word(row['secure']),
+          true_false_word(secure),
           row['expires_utc'],
           row['name'],
           row['value']

--- a/lib/cookie_extractor/common.rb
+++ b/lib/cookie_extractor/common.rb
@@ -15,5 +15,42 @@ module CookieExtractor
         raise "Invalid value passed to true_false_word: #{value.inspect}"
       end
     end
+
+    def cookie_applies?(domain, host)
+      dot_domain = is_domain_wide(domain)
+      dot_host = is_domain_wide(host)
+
+      domain = domain.delete_prefix('.').downcase
+      host = host.delete_prefix('.').downcase
+
+      return true if domain == host || dot_domain && host.end_with?(".#{domain}")
+      dot_host && domain.end_with?(".#{host}")
+    end
+
+    def cookie_line(domain, path, secure, expires, name, value, format: :netscape)
+      case format
+      when :netscape
+        [
+          domain,
+          true_false_word(is_domain_wide(domain)),
+          path,
+          true_false_word(secure),
+          expires,
+          name,
+          value
+        ].join("\t")
+      when :hash, false
+        {
+          domain: domain,
+          path: path,
+          secure: true_false_word(secure) == 'TRUE',
+          expires: expires.to_i,
+          name: name,
+          value: value
+        }
+      else
+        raise ArgumentError, "unsupported format: #{format.inspect}"
+      end
+    end
   end
 end

--- a/lib/cookie_extractor/firefox_cookie_extractor.rb
+++ b/lib/cookie_extractor/firefox_cookie_extractor.rb
@@ -12,12 +12,16 @@ module CookieExtractor
       db = SQLite3::Database.new @cookie_file
       db.results_as_hash = true
       result = []
+      schema_version = db.get_first_value('PRAGMA user_version;').to_i
       db.execute("SELECT * FROM moz_cookies") do |row|
+        expiry = row['expiry']
+        # Firefox 142+ (schema version 16) started using milliseconds for expiry
+        expiry = expiry.to_i / 1000 if schema_version >= 16
         result << [ row['host'],
           true_false_word(is_domain_wide(row['host'])),
           row['path'],
           true_false_word(row['isSecure']),
-          row['expiry'],
+          expiry,
           row['name'],
           row['value']
         ].join("\t")

--- a/lib/cookie_extractor/firefox_cookie_extractor.rb
+++ b/lib/cookie_extractor/firefox_cookie_extractor.rb
@@ -8,23 +8,18 @@ module CookieExtractor
       @cookie_file = cookie_file
     end
 
-    def extract
+    def extract(format: :netscape, domain: nil)
       db = SQLite3::Database.new @cookie_file
       db.results_as_hash = true
       result = []
       schema_version = db.get_first_value('PRAGMA user_version;').to_i
       db.execute("SELECT * FROM moz_cookies") do |row|
+        next unless domain.nil? || cookie_applies?(row['host'], domain)
+
         expiry = row['expiry']
         # Firefox 142+ (schema version 16) started using milliseconds for expiry
         expiry = expiry.to_i / 1000 if schema_version >= 16
-        result << [ row['host'],
-          true_false_word(is_domain_wide(row['host'])),
-          row['path'],
-          true_false_word(row['isSecure']),
-          expiry,
-          row['name'],
-          row['value']
-        ].join("\t")
+        result << cookie_line(row['host'], row['path'], row['isSecure'], expiry, row['name'], row['value'], format: format)
       end
       db.close
       result

--- a/spec/browser_detector_spec.rb
+++ b/spec/browser_detector_spec.rb
@@ -3,14 +3,14 @@ require File.join(File.dirname(__FILE__), "spec_helper")
 describe CookieExtractor::BrowserDetector, "determining the correct extractor to use" do
   before :each do
     @fake_cookie_db = double("cookie database", :close => true)
-    SQLite3::Database.should_receive(:new).
+    expect(SQLite3::Database).to receive(:new).
       with('filename').
         and_return(@fake_cookie_db)
   end
 
   describe "given a sqlite database with a 'moz_cookies' table" do
     before :each do
-      @fake_cookie_db.should_receive(:table_info).
+      expect(@fake_cookie_db).to receive(:table_info).
         with("moz_cookies").
           and_return(
             { 'name' => 'some_field',
@@ -19,16 +19,16 @@ describe CookieExtractor::BrowserDetector, "determining the correct extractor to
 
     it "should return a firefox extractor instance" do
       extractor = CookieExtractor::BrowserDetector.new_extractor('filename')
-      extractor.instance_of?(CookieExtractor::FirefoxCookieExtractor).should be_true
+      expect(extractor.instance_of?(CookieExtractor::FirefoxCookieExtractor)).to be true
     end
   end
 
   describe "given a sqlite database with a 'cookies' table" do
     before :each do
-      @fake_cookie_db.should_receive(:table_info).
+      expect(@fake_cookie_db).to receive(:table_info).
         with("moz_cookies").
           and_return([])
-      @fake_cookie_db.should_receive(:table_info).
+      expect(@fake_cookie_db).to receive(:table_info).
         with("cookies").
           and_return(
             [{ 'name' => 'some_field',
@@ -37,7 +37,7 @@ describe CookieExtractor::BrowserDetector, "determining the correct extractor to
 
     it "should return a chrome extractor instance" do
       extractor = CookieExtractor::BrowserDetector.new_extractor('filename')
-      extractor.instance_of?(CookieExtractor::ChromeCookieExtractor).should be_true
+      expect(extractor.instance_of?(CookieExtractor::ChromeCookieExtractor)).to be true
     end
   end
 end
@@ -45,33 +45,33 @@ end
 describe CookieExtractor::BrowserDetector, "guessing the location of the cookie file" do
   describe "when no cookie files are found in the standard locations" do
     before :each do
-      Dir.stub!(:glob).and_return([])
+      allow(Dir).to receive(:glob).and_return([])
     end
 
     it "should raise NoCookieFileFoundException" do
-      lambda { CookieExtractor::BrowserDetector.guess }.
-        should raise_error(CookieExtractor::NoCookieFileFoundException)
+      expect { CookieExtractor::BrowserDetector.guess }.
+        to raise_error(CookieExtractor::NoCookieFileFoundException)
     end
   end
 
   describe "when multiple cookie files are found in the standard locations" do
     before :each do
       cookie_locations = CookieExtractor::BrowserDetector::COOKIE_LOCATIONS
-      Dir.stub!(:glob).and_return([cookie_locations['chrome']],
+      allow(Dir).to receive(:glob).and_return([cookie_locations['chrome']],
                                   [],
                                   [cookie_locations['firefox']])
     end
 
     describe "and chrome was the most recently used" do
       before :each do
-        File.should_receive(:mtime).twice.and_return(
+        expect(File).to receive(:mtime).twice.and_return(
           Time.parse("July 2 2013 00:00:00"),
           Time.parse("July 1 2013 00:00:00"))
       end
 
       it "should build a ChromeCookieExtractor" do
-        CookieExtractor::BrowserDetector.
-          should_receive(:browser_extractor).
+        expect(CookieExtractor::BrowserDetector).
+          to receive(:browser_extractor).
             once.with("chrome")
         CookieExtractor::BrowserDetector.guess
       end

--- a/spec/browser_detector_spec.rb
+++ b/spec/browser_detector_spec.rb
@@ -56,10 +56,14 @@ describe CookieExtractor::BrowserDetector, "guessing the location of the cookie 
 
   describe "when multiple cookie files are found in the standard locations" do
     before :each do
-      cookie_locations = CookieExtractor::BrowserDetector::COOKIE_LOCATIONS
-      allow(Dir).to receive(:glob).and_return([cookie_locations['chrome']],
-                                  [],
-                                  [cookie_locations['firefox']])
+      chrome_path = File.expand_path(CookieExtractor::BrowserDetector.cookie_locations("chrome").first)
+      firefox_path = File.expand_path(CookieExtractor::BrowserDetector.cookie_locations("firefox").first)
+      allow(Dir).to receive(:glob).and_return(
+        [chrome_path],
+        [],
+        [firefox_path],
+        []
+      )
     end
 
     describe "and chrome was the most recently used" do
@@ -70,9 +74,10 @@ describe CookieExtractor::BrowserDetector, "guessing the location of the cookie 
       end
 
       it "should build a ChromeCookieExtractor" do
+        chrome_path = File.expand_path(CookieExtractor::BrowserDetector.cookie_locations("chrome").first)
         expect(CookieExtractor::BrowserDetector).
           to receive(:browser_extractor).
-            once.with("chrome")
+            once.with(nil, chrome_path)
         CookieExtractor::BrowserDetector.guess
       end
     end

--- a/spec/chrome_cookie_extractor_spec.rb
+++ b/spec/chrome_cookie_extractor_spec.rb
@@ -5,14 +5,14 @@ describe CookieExtractor::ChromeCookieExtractor do
     @fake_cookie_db = double("cookie database",
       :results_as_hash= => true,
       :close => true)
-    SQLite3::Database.should_receive(:new).
+    expect(SQLite3::Database).to receive(:new).
       with('filename').
         and_return(@fake_cookie_db)
   end
 
   describe "opening and closing a sqlite db" do
     before :each do
-      @fake_cookie_db.should_receive(:execute).and_yield(
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
         { 'host_key' => '.dallien.net',
           'path' => '/',
           'secure' => '0',
@@ -23,14 +23,14 @@ describe CookieExtractor::ChromeCookieExtractor do
     end
 
     it "should close the db when finished" do
-      @fake_cookie_db.should_receive(:close)
+      expect(@fake_cookie_db).to receive(:close)
       @extractor.extract
     end
   end
 
   describe "with a cookie that has a host starting with a dot" do
     before :each do
-      @fake_cookie_db.should_receive(:execute).and_yield(
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
         { 'host_key' => '.dallien.net',
           'path' => '/',
           'secure' => '0',
@@ -42,24 +42,24 @@ describe CookieExtractor::ChromeCookieExtractor do
     end
 
     it "should return one cookie string" do
-      @result.size.should == 1
+      expect(@result.size).to eq(1)
     end
 
     it "should put TRUE in the domain wide field" do
       cookie_string = @result.first
-      cookie_string.split("\t")[1].should == "TRUE"
+      expect(cookie_string.split("\t")[1]).to eq("TRUE")
     end
 
     it "should build the correct cookie string" do
       cookie_string = @result.first
-      cookie_string.should ==
-        ".dallien.net\tTRUE\t/\tFALSE\t1234567890\tNAME\tVALUE"
+      expect(cookie_string).to eq(
+        ".dallien.net\tTRUE\t/\tFALSE\t1234567890\tNAME\tVALUE")
     end
   end
 
   describe "with a cookie that has a host not starting with a dot" do
     before :each do
-      @fake_cookie_db.should_receive(:execute).and_yield(
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
         { 'host_key' => 'jeff.dallien.net',
           'path' => '/path',
           'secure' => '1',
@@ -71,24 +71,24 @@ describe CookieExtractor::ChromeCookieExtractor do
     end
 
     it "should return one cookie string" do
-      @result.size.should == 1
+      expect(@result.size).to eq(1)
     end
 
     it "should put FALSE in the domain wide field" do
       cookie_string = @result.first
-      cookie_string.split("\t")[1].should == "FALSE"
+      expect(cookie_string.split("\t")[1]).to eq("FALSE")
     end
 
     it "should build the correct cookie string" do
       cookie_string = @result.first
-      cookie_string.should ==
-        "jeff.dallien.net\tFALSE\t/path\tTRUE\t1234567890\tNAME\tVALUE"
+      expect(cookie_string).to eq(
+        "jeff.dallien.net\tFALSE\t/path\tTRUE\t1234567890\tNAME\tVALUE")
     end
   end
 
   describe "with a cookie that is not marked as secure" do
     before :each do
-      @fake_cookie_db.should_receive(:execute).and_yield(
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
         { 'host_key' => '.dallien.net',
           'path' => '/',
           'secure' => '0',
@@ -101,13 +101,13 @@ describe CookieExtractor::ChromeCookieExtractor do
 
     it "should put FALSE in the secure field" do
       cookie_string = @result.first
-      cookie_string.split("\t")[3].should == "FALSE"
+      expect(cookie_string.split("\t")[3]).to eq("FALSE")
     end
   end
 
   describe "with a cookie that is marked as secure" do
     before :each do
-      @fake_cookie_db.should_receive(:execute).and_yield(
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
         { 'host_key' => '.dallien.net',
           'path' => '/',
           'secure' => '1',
@@ -120,7 +120,7 @@ describe CookieExtractor::ChromeCookieExtractor do
 
     it "should put TRUE in the secure field" do
       cookie_string = @result.first
-      cookie_string.split("\t")[3].should == "TRUE"
+      expect(cookie_string.split("\t")[3]).to eq("TRUE")
     end
   end
 end

--- a/spec/chrome_cookie_extractor_spec.rb
+++ b/spec/chrome_cookie_extractor_spec.rb
@@ -123,4 +123,24 @@ describe CookieExtractor::ChromeCookieExtractor do
       expect(cookie_string.split("\t")[3]).to eq("TRUE")
     end
   end
+
+  describe "with is_secure column" do
+    before :each do
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
+        { 'host_key' => '.dallien.net',
+          'path' => '/',
+          'is_secure' => '1',
+          'expires_utc' => '1234567890',
+          'name' => 'NAME',
+          'value' => 'VALUE'})
+      @extractor = CookieExtractor::ChromeCookieExtractor.new('filename')
+      @result = @extractor.extract
+    end
+
+    it "should put TRUE in the secure field" do
+      cookie_string = @result.first
+      expect(cookie_string.split("\t")[3]).to eq("TRUE")
+    end
+
+  end
 end

--- a/spec/chrome_cookie_extractor_spec.rb
+++ b/spec/chrome_cookie_extractor_spec.rb
@@ -141,6 +141,26 @@ describe CookieExtractor::ChromeCookieExtractor do
       cookie_string = @result.first
       expect(cookie_string.split("\t")[3]).to eq("TRUE")
     end
+  end
 
+  describe "with domain filter" do
+    before :each do
+      expect(@fake_cookie_db).to receive(:execute) do |&block|
+        block.call({'host_key' => '.example.com', 'path' => '/', 'is_secure' => '0', 'expires_utc' => '1787601234000', 'name' => 'NAME', 'value' => 'EXAMPLE VALUE'})
+        block.call({'host_key' => '.other.test', 'path' => '/', 'is_secure' => '0', 'expires_utc' => '1787601234000', 'name' => 'NAME2', 'value' => 'OTHER VALUE'})
+      end
+      @extractor = CookieExtractor::ChromeCookieExtractor.new('filename')
+    end
+
+    it "returns correct domain" do
+      result = @extractor.extract(domain: "example.com", format: :hash)
+      expect(result.size).to eq(1)
+      expect(result.first[:value]).to eq("EXAMPLE VALUE")
+    end
+
+    it "returns all when domain is nil" do
+      result = @extractor.extract(format: :hash)
+      expect(result.size).to eq(2)
+    end
   end
 end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -1,0 +1,60 @@
+require_relative "spec_helper"
+
+describe CookieExtractor::Common do
+  let(:common) do
+    Class.new { include CookieExtractor::Common }.new
+  end
+
+  describe "#cookie_applies?" do
+    it "matches domain" do
+      expect(common.send(:cookie_applies?, "example.com", "example.com")).to be true
+      expect(common.send(:cookie_applies?, ".other.test", "example.com")).to be false
+    end
+
+    it "matches dot domain" do
+      expect(common.send(:cookie_applies?, ".example.com", "example.com")).to be true
+    end
+
+    it "matches subdomain" do
+      expect(common.send(:cookie_applies?, ".example.com", "www.example.com")).to be true
+      expect(common.send(:cookie_applies?, ".example.com", "api.example.com")).to be true
+    end
+
+    it "does not match host-only cookie to subdomain" do
+      expect(common.send(:cookie_applies?, "example.com", "www.example.com")).to be false
+      expect(common.send(:cookie_applies?, "example.com", "api.example.com")).to be false
+    end
+
+    it "does not match subdomain cookie" do
+      expect(common.send(:cookie_applies?, "www.example.com", "example.com")).to be false
+    end
+
+    it "is case-insensitive" do
+      expect(common.send(:cookie_applies?, ".Example.COM", "example.com")).to be true
+      expect(common.send(:cookie_applies?, ".example.com", "EXAMPLE.COM")).to be true
+    end
+
+    it "handles host filter" do
+      expect(common.send(:cookie_applies?, "sub.example.com", ".example.com")).to be true
+      expect(common.send(:cookie_applies?, "other.com", ".example.com")).to be false
+    end
+  end
+
+  describe "#cookie_line" do
+    it "builds netscape format" do
+      line = common.send(:cookie_line, ".dallien.net", "/", "0", "1234567890", "NAME", "VALUE", format: :netscape)
+      expect(line).to eq(".dallien.net\tTRUE\t/\tFALSE\t1234567890\tNAME\tVALUE")
+    end
+
+    it "builds hash format with format: :hash" do
+      h = common.send(:cookie_line, ".dallien.net", "/", "0", "1234567890", "NAME", "VALUE", format: :hash)
+      expect(h).to eq(domain: ".dallien.net", path: "/", secure: false, expires: 1234567890, name: "NAME", value: "VALUE")
+    end
+
+    it "builds hash format with format: false" do
+      h = common.send(:cookie_line, ".dallien.net", "/", 1, "1234567890", "NAME", "VALUE", format: false)
+      expect(h[:secure]).to eq(true)
+      expect(h[:expires]).to eq(1234567890)
+    end
+  end
+end

--- a/spec/firefox_cookie_extractor_spec.rb
+++ b/spec/firefox_cookie_extractor_spec.rb
@@ -138,4 +138,28 @@ describe CookieExtractor::FirefoxCookieExtractor do
       expect(cookie_string.split("\t")[3]).to eq("TRUE")
     end
   end
+
+  describe "with domain filter" do
+    before :each do
+      expect(@fake_cookie_db).to receive(:get_first_value).and_return(16)
+      expect(@fake_cookie_db).to receive(:execute) do |&block|
+        block.call({'host' => '.example.com', 'path' => '/', 'isSecure' => '0', 'expiry' => '1787601234000', 'name' => 'NAME', 'value' => 'EXAMPLE VALUE'})
+        block.call({'host' => '.other.test', 'path' => '/', 'isSecure' => '0', 'expiry' => '1787601234000', 'name' => 'NAME2', 'value' => 'OTHER VALUE'})
+      end
+      @extractor = CookieExtractor::FirefoxCookieExtractor.new('filename')
+      allow(@fake_cookie_db).to receive(:close)
+    end
+
+    it "returns correct domain" do
+      result = @extractor.extract(domain: "example.com", format: :hash)
+      expect(result.size).to eq(1)
+      expect(result.first[:value]).to eq("EXAMPLE VALUE")
+      expect(result.first[:expires]).to eq(1787601234)
+    end
+
+    it "returns all when domain is nil" do
+      result = @extractor.extract(format: :hash)
+      expect(result.size).to eq(2)
+    end
+  end
 end

--- a/spec/firefox_cookie_extractor_spec.rb
+++ b/spec/firefox_cookie_extractor_spec.rb
@@ -5,14 +5,14 @@ describe CookieExtractor::FirefoxCookieExtractor do
     @fake_cookie_db = double("cookie database",
       :results_as_hash= => true,
       :close => true)
-    SQLite3::Database.should_receive(:new).
+    expect(SQLite3::Database).to receive(:new).
       with('filename').
         and_return(@fake_cookie_db)
   end
 
   describe "opening and closing a sqlite db" do
     before :each do
-      @fake_cookie_db.should_receive(:execute).and_yield(
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
         {'host' => '.dallien.net',
           'path' => '/',
           'isSecure' => '0',
@@ -23,14 +23,14 @@ describe CookieExtractor::FirefoxCookieExtractor do
     end
 
     it "should close the db when finished" do
-      @fake_cookie_db.should_receive(:close)
+      expect(@fake_cookie_db).to receive(:close)
       @extractor.extract
     end
   end
 
   describe "with a cookie that has a host starting with a dot" do
     before :each do
-      @fake_cookie_db.should_receive(:execute).and_yield(
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
         {'host' => '.dallien.net',
           'path' => '/',
           'isSecure' => '0',
@@ -42,29 +42,29 @@ describe CookieExtractor::FirefoxCookieExtractor do
     end
 
     it "should return one cookie string" do
-      @result.size.should == 1
+      expect(@result.size).to eq(1)
     end
 
     it "should put TRUE in the domain wide field" do
       cookie_string = @result.first
-      cookie_string.split("\t")[1].should == "TRUE"
+      expect(cookie_string.split("\t")[1]).to eq("TRUE")
     end
 
     it "should put FALSE in the secure field" do
       cookie_string = @result.first
-      cookie_string.split("\t")[3].should == "FALSE"
+      expect(cookie_string.split("\t")[3]).to eq("FALSE")
     end
 
     it "should build the correct cookie string" do
       cookie_string = @result.first
-      cookie_string.should ==
-        ".dallien.net\tTRUE\t/\tFALSE\t1234567890\tNAME\tVALUE"
+      expect(cookie_string).to eq(
+        ".dallien.net\tTRUE\t/\tFALSE\t1234567890\tNAME\tVALUE")
     end
   end
 
   describe "with a cookie that has a host not starting with a dot" do
     before :each do
-      @fake_cookie_db.should_receive(:execute).and_yield(
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
         { 'host' => 'jeff.dallien.net',
           'path' => '/path',
           'isSecure' => '1',
@@ -76,29 +76,29 @@ describe CookieExtractor::FirefoxCookieExtractor do
     end
 
     it "should return one cookie string" do
-      @result.size.should == 1
+      expect(@result.size).to eq(1)
     end
 
     it "should put FALSE in the domain wide field" do
       cookie_string = @result.first
-      cookie_string.split("\t")[1].should == "FALSE"
+      expect(cookie_string.split("\t")[1]).to eq("FALSE")
     end
 
     it "should put TRUE in the secure field" do
       cookie_string = @result.first
-      cookie_string.split("\t")[3].should == "TRUE"
+      expect(cookie_string.split("\t")[3]).to eq("TRUE")
     end
 
     it "should build the correct cookie string" do
       cookie_string = @result.first
-      cookie_string.should ==
-        "jeff.dallien.net\tFALSE\t/path\tTRUE\t1234567890\tNAME\tVALUE"
+      expect(cookie_string).to eq(
+        "jeff.dallien.net\tFALSE\t/path\tTRUE\t1234567890\tNAME\tVALUE")
     end
   end
 
   describe "with a cookie that is not marked as secure" do
     before :each do
-      @fake_cookie_db.should_receive(:execute).and_yield(
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
         {'host' => '.dallien.net',
           'path' => '/',
           'isSecure' => '0',
@@ -111,13 +111,13 @@ describe CookieExtractor::FirefoxCookieExtractor do
 
     it "should put FALSE in the secure field" do
       cookie_string = @result.first
-      cookie_string.split("\t")[3].should == "FALSE"
+      expect(cookie_string.split("\t")[3]).to eq("FALSE")
     end
   end
 
   describe "with a cookie that is marked as secure" do
     before :each do
-      @fake_cookie_db.should_receive(:execute).and_yield(
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
         {'host' => '.dallien.net',
           'path' => '/',
           'isSecure' => '1',
@@ -130,7 +130,7 @@ describe CookieExtractor::FirefoxCookieExtractor do
 
     it "should put TRUE in the secure field" do
       cookie_string = @result.first
-      cookie_string.split("\t")[3].should == "TRUE"
+      expect(cookie_string.split("\t")[3]).to eq("TRUE")
     end
   end
 end

--- a/spec/firefox_cookie_extractor_spec.rb
+++ b/spec/firefox_cookie_extractor_spec.rb
@@ -12,6 +12,7 @@ describe CookieExtractor::FirefoxCookieExtractor do
 
   describe "opening and closing a sqlite db" do
     before :each do
+      expect(@fake_cookie_db).to receive(:get_first_value).and_return(15)
       expect(@fake_cookie_db).to receive(:execute).and_yield(
         {'host' => '.dallien.net',
           'path' => '/',
@@ -30,6 +31,7 @@ describe CookieExtractor::FirefoxCookieExtractor do
 
   describe "with a cookie that has a host starting with a dot" do
     before :each do
+      expect(@fake_cookie_db).to receive(:get_first_value).and_return(15)
       expect(@fake_cookie_db).to receive(:execute).and_yield(
         {'host' => '.dallien.net',
           'path' => '/',
@@ -64,6 +66,7 @@ describe CookieExtractor::FirefoxCookieExtractor do
 
   describe "with a cookie that has a host not starting with a dot" do
     before :each do
+      expect(@fake_cookie_db).to receive(:get_first_value).and_return(15)
       expect(@fake_cookie_db).to receive(:execute).and_yield(
         { 'host' => 'jeff.dallien.net',
           'path' => '/path',
@@ -98,6 +101,7 @@ describe CookieExtractor::FirefoxCookieExtractor do
 
   describe "with a cookie that is not marked as secure" do
     before :each do
+      expect(@fake_cookie_db).to receive(:get_first_value).and_return(15)
       expect(@fake_cookie_db).to receive(:execute).and_yield(
         {'host' => '.dallien.net',
           'path' => '/',
@@ -117,6 +121,7 @@ describe CookieExtractor::FirefoxCookieExtractor do
 
   describe "with a cookie that is marked as secure" do
     before :each do
+      expect(@fake_cookie_db).to receive(:get_first_value).and_return(15)
       expect(@fake_cookie_db).to receive(:execute).and_yield(
         {'host' => '.dallien.net',
           'path' => '/',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
+require 'time'
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "cookie_extractor"))
 


### PR DESCRIPTION
This PR contains several improvements:
* Replace File.exists? with File.exist? (dropped from Ruby 3.2+)
* Fix `browser` typo
* Update tests to use RSpec expect syntax
* Update gems (`sqlite-ruby` gem was renamed to `sqlite`)
* Create default Rake spec task for running tests
* Update ChromeCookieExtractor to support `is_secure` column (similar as #3 but with backwards compatibility)
* Update cookie location search to find more cookies (needed for newer Firefox)
* Fix `expiry` for Firefox 142+
* Implement support for Hash format and domain filter (useful when used as library)
