### PR TITLE
Finish Firefox support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,14 @@ PATH
   remote: .
   specs:
     cookie_extractor (0.2.0)
+      extlz4 (~> 0.3)
       sqlite3 (~> 2.9)
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.6.2)
+    extlz4 (0.3.5)
     mini_portile2 (2.8.9)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)

--- a/cookie_extractor.gemspec
+++ b/cookie_extractor.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec", "~> 3.13"
   s.add_runtime_dependency "sqlite3", "~> 2.9"
+  s.add_runtime_dependency "extlz4", "~> 0.3"
 end

--- a/lib/cookie_extractor/browser_detector.rb
+++ b/lib/cookie_extractor/browser_detector.rb
@@ -1,3 +1,5 @@
+require_relative 'common'
+
 module CookieExtractor
   class BrowserNotDetectedException < Exception; end
   class InvalidBrowserNameException < Exception; end
@@ -47,14 +49,15 @@ module CookieExtractor
     end
 
     def self.detect_browser(db_filename)
-      db = SQLite3::Database.new(db_filename)
-      browser = 
-        if has_table?(db, 'moz_cookies')
-          'Firefox'
-        elsif has_table?(db, 'cookies')
-          'Chrome'
-        end
-      db.close
+      browser = nil
+      Common::with_sqlite(db_filename) do |db|
+        browser =
+          if has_table?(db, 'moz_cookies')
+            'Firefox'
+          elsif has_table?(db, 'cookies')
+            'Chrome'
+          end
+      end
       browser
     end
 

--- a/lib/cookie_extractor/chrome_cookie_extractor.rb
+++ b/lib/cookie_extractor/chrome_cookie_extractor.rb
@@ -1,4 +1,4 @@
-require 'sqlite3'
+require_relative 'common'
 
 module CookieExtractor
   class ChromeCookieExtractor
@@ -9,16 +9,15 @@ module CookieExtractor
     end
 
     def extract(format: :netscape, domain: nil)
-      db = SQLite3::Database.new @cookie_file
-      db.results_as_hash = true
       result = []
-      db.execute("SELECT * FROM cookies") do |row|
-        next unless domain.nil? || cookie_applies?(row['host_key'], domain)
+      with_sqlite(@cookie_file) do |db|
+        db.execute("SELECT * FROM cookies") do |row|
+          next unless domain.nil? || cookie_applies?(row['host_key'], domain)
 
-        secure = row.key?('is_secure') ? row['is_secure'] : row['secure']
-        result << cookie_line(row['host_key'], row['path'], secure, row['expires_utc'], row['name'], row['value'], format: format)
+          secure = row.key?('is_secure') ? row['is_secure'] : row['secure']
+          result << cookie_line(row['host_key'], row['path'], secure, row['expires_utc'], row['name'], row['value'], format: format)
+        end
       end
-      db.close
       result
     end
   end

--- a/lib/cookie_extractor/common.rb
+++ b/lib/cookie_extractor/common.rb
@@ -1,6 +1,34 @@
+require 'uri'
+require 'sqlite3'
+
 module CookieExtractor
   module Common
     private
+
+    def self.with_sqlite(path)
+      flags = SQLite3::Constants::Open::READONLY | SQLite3::Constants::Open::URI
+      db = nil
+      begin
+        db = SQLite3::Database.new(file_uri(path, :immutable => 0).to_s, flags: flags)
+        db.execute("SELECT name FROM sqlite_schema LIMIT 1;")
+      rescue SQLite3::BusyException
+        db = SQLite3::Database.new(file_uri(path, :immutable => 1).to_s, flags: flags)
+      end
+      db.results_as_hash = true
+      yield db
+    ensure
+      db&.close
+    end
+
+    def with_sqlite(path, &block)
+      Common::with_sqlite(path, &block)
+    end
+
+    def self.file_uri(path, query)
+      path = File.expand_path(path)
+      URI::File.build(:path => URI::RFC2396_PARSER.escape(path),
+                      :query => query ? URI.encode_www_form(query) : nil)
+    end
 
     def is_domain_wide(hostname)
       hostname[0..0] == "."

--- a/lib/cookie_extractor/common.rb
+++ b/lib/cookie_extractor/common.rb
@@ -30,6 +30,20 @@ module CookieExtractor
                       :query => query ? URI.encode_www_form(query) : nil)
     end
 
+    def file_binread(path, retries: 5, delay: 0.05)
+      attempts = 1
+      begin
+        File.read(path)
+      rescue Errno::ENOENT => error
+        attempts += 1
+        if attempts <= retries
+          sleep(delay)
+          retry
+        end
+        raise error
+      end
+    end
+
     def is_domain_wide(hostname)
       hostname[0..0] == "."
     end

--- a/lib/cookie_extractor/firefox_cookie_extractor.rb
+++ b/lib/cookie_extractor/firefox_cookie_extractor.rb
@@ -1,3 +1,5 @@
+require 'json'
+require 'extlz4'
 
 require_relative 'common'
 
@@ -7,9 +9,15 @@ module CookieExtractor
 
     def initialize(cookie_file)
       @cookie_file = cookie_file
+      @recovery_file = File.dirname(@cookie_file) + '/sessionstore-backups/recovery.jsonlz4'
+      @recovery_file = nil unless File.exist?(@recovery_file)
     end
 
     def extract(format: :netscape, domain: nil)
+      persistent_cookies(format: format, domain: domain) + session_cookies(format: format, domain: domain)
+    end
+
+    def persistent_cookies(format:, domain:)
       result = []
       with_sqlite(@cookie_file) do |db|
         schema_version = db.get_first_value('PRAGMA user_version;').to_i
@@ -24,5 +32,21 @@ module CookieExtractor
       end
       result
     end
+
+    def session_cookies(format:, domain:)
+      return [] unless @recovery_file
+      data = file_binread(@recovery_file)
+      if data[0..7] == "mozLz40\0"
+         json = LZ4.block_decode(data[12..-1])
+         recovery = JSON.parse(json)
+         recovery['cookies'].to_a.filter_map do |cookie|
+           next unless domain.nil? || cookie_applies?(cookie['host'], domain)
+           cookie_line(cookie['host'], cookie['path'], !!cookie['secure'], 0, cookie['name'], cookie['value'], format: format)
+         end
+      else
+        []
+      end
+    end
+
   end
 end

--- a/lib/cookie_extractor/firefox_cookie_extractor.rb
+++ b/lib/cookie_extractor/firefox_cookie_extractor.rb
@@ -1,4 +1,5 @@
-require 'sqlite3'
+
+require_relative 'common'
 
 module CookieExtractor
   class FirefoxCookieExtractor
@@ -9,19 +10,18 @@ module CookieExtractor
     end
 
     def extract(format: :netscape, domain: nil)
-      db = SQLite3::Database.new @cookie_file
-      db.results_as_hash = true
       result = []
-      schema_version = db.get_first_value('PRAGMA user_version;').to_i
-      db.execute("SELECT * FROM moz_cookies") do |row|
-        next unless domain.nil? || cookie_applies?(row['host'], domain)
+      with_sqlite(@cookie_file) do |db|
+        schema_version = db.get_first_value('PRAGMA user_version;').to_i
+        db.execute("SELECT * FROM moz_cookies") do |row|
+          next unless domain.nil? || cookie_applies?(row['host'], domain)
 
-        expiry = row['expiry']
-        # Firefox 142+ (schema version 16) started using milliseconds for expiry
-        expiry = expiry.to_i / 1000 if schema_version >= 16
-        result << cookie_line(row['host'], row['path'], row['isSecure'], expiry, row['name'], row['value'], format: format)
+          expiry = row['expiry']
+          # Firefox 142+ (schema version 16) started using milliseconds for expiry
+          expiry = expiry.to_i / 1000 if schema_version >= 16
+          result << cookie_line(row['host'], row['path'], row['isSecure'], expiry, row['name'], row['value'], format: format)
+        end
       end
-      db.close
       result
     end
   end

--- a/spec/browser_detector_spec.rb
+++ b/spec/browser_detector_spec.rb
@@ -2,10 +2,9 @@ require File.join(File.dirname(__FILE__), "spec_helper")
 
 describe CookieExtractor::BrowserDetector, "determining the correct extractor to use" do
   before :each do
-    @fake_cookie_db = double("cookie database", :close => true)
-    expect(SQLite3::Database).to receive(:new).
-      with('filename').
-        and_return(@fake_cookie_db)
+    @fake_cookie_db = double("cookie database")
+    allow(CookieExtractor::Common).to receive(:with_sqlite).and_call_original
+    allow(CookieExtractor::Common).to receive(:with_sqlite).with('filename').and_yield(@fake_cookie_db)
   end
 
   describe "given a sqlite database with a 'moz_cookies' table" do
@@ -38,6 +37,24 @@ describe CookieExtractor::BrowserDetector, "determining the correct extractor to
     it "should return a chrome extractor instance" do
       extractor = CookieExtractor::BrowserDetector.new_extractor('filename')
       expect(extractor.instance_of?(CookieExtractor::ChromeCookieExtractor)).to be true
+    end
+  end
+
+  describe "with real opened DB" do
+    it "reads cookies even when DB is locked" do
+      path = create_sqlite_db(
+        [["item", "value", ".example.org", "/", 123, 1]],
+        table_name: "moz_cookies",
+        table_sql: "CREATE TABLE moz_cookies (name TEXT, value TEXT, host TEXT, path TEXT, expiry INTEGER, isSecure INTEGER)"
+      )
+      db = SQLite3::Database.new(path)
+      db.execute("BEGIN EXCLUSIVE")
+      begin
+        extractor = CookieExtractor::BrowserDetector.new_extractor(path)
+        expect(extractor.extract(format: false)).to eq([{domain: ".example.org", expires: 123, name: "item", path: "/", secure: true, value: "value"}])
+      ensure
+        db.close
+      end
     end
   end
 end

--- a/spec/chrome_cookie_extractor_spec.rb
+++ b/spec/chrome_cookie_extractor_spec.rb
@@ -2,30 +2,9 @@ require File.join(File.dirname(__FILE__), "spec_helper")
 
 describe CookieExtractor::ChromeCookieExtractor do
   before :each do
-    @fake_cookie_db = double("cookie database",
-      :results_as_hash= => true,
-      :close => true)
-    expect(SQLite3::Database).to receive(:new).
-      with('filename').
-        and_return(@fake_cookie_db)
-  end
-
-  describe "opening and closing a sqlite db" do
-    before :each do
-      expect(@fake_cookie_db).to receive(:execute).and_yield(
-        { 'host_key' => '.dallien.net',
-          'path' => '/',
-          'secure' => '0',
-          'expires_utc' => '1234567890',
-          'name' => 'NAME',
-          'value' => 'VALUE'})
-      @extractor = CookieExtractor::ChromeCookieExtractor.new('filename')
-    end
-
-    it "should close the db when finished" do
-      expect(@fake_cookie_db).to receive(:close)
-      @extractor.extract
-    end
+    @fake_cookie_db = double("cookie database")
+    allow(CookieExtractor::Common).to receive(:with_sqlite).and_call_original
+    allow(CookieExtractor::Common).to receive(:with_sqlite).with('filename').and_yield(@fake_cookie_db)
   end
 
   describe "with a cookie that has a host starting with a dot" do

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -139,4 +139,31 @@ describe CookieExtractor::Common do
       end
     end
   end
+
+  describe "#file_binread" do
+    it "retries on ENOENT and succeeds" do
+      attempts = 0
+      allow(File).to receive(:read) do |_path|
+        attempts += 1
+        raise Errno::ENOENT, "no file" if attempts < 3
+        "content"
+      end
+      allow(Kernel).to receive(:sleep)
+      result = common.send(:file_binread, "/tmp/missing", retries: 5, delay: 0.01)
+      expect(result).to eq("content")
+      expect(attempts).to eq(3)
+    end
+
+    it "raises after retries exhausted" do
+      allow(File).to receive(:read).and_raise(Errno::ENOENT, "no file")
+      allow(Kernel).to receive(:sleep)
+      expect { common.send(:file_binread, "/tmp/missing", retries: 2, delay: 0.01) }.to raise_error(Errno::ENOENT)
+    end
+
+    it "does not retry on other errors" do
+      allow(File).to receive(:read).and_raise(Errno::EACCES, "permission")
+      expect(Kernel).not_to receive(:sleep)
+      expect { common.send(:file_binread, "/tmp/test") }.to raise_error(Errno::EACCES)
+    end
+  end
 end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -57,4 +57,86 @@ describe CookieExtractor::Common do
       expect(h[:expires]).to eq(1234567890)
     end
   end
+
+  describe ".file_uri" do
+    it "builds file uri with immutable" do
+      uri = CookieExtractor::Common.file_uri("/tmp/foo + bar.sqlite", immutable: 1)
+      expect(uri.scheme).to eq("file")
+      expect(uri.path).to eq("/tmp/foo%20+%20bar.sqlite")
+      expect(uri.query).to eq("immutable=1")
+      expect(uri.to_s).to eq("file:///tmp/foo%20+%20bar.sqlite?immutable=1")
+    end
+
+    it "builds file uri without query when nil" do
+      uri = CookieExtractor::Common.file_uri("/tmp/foo.sqlite", nil)
+      expect(uri.query).to be_nil
+    end
+
+    it "expands relative path to absolute" do
+      relative = "relative_test.sqlite"
+      path = File.expand_path(relative)
+      uri = CookieExtractor::Common.file_uri(relative, immutable: 1)
+      expect(uri.path).to eq(URI::RFC2396_PARSER.escape(path))
+    end
+  end
+
+  describe ".with_sqlite" do
+    let(:table_sql) { "CREATE TABLE test (id INTEGER, item TEXT)" }
+    let(:db_file) { create_sqlite_db([[1, "item value"]], table_name: "test", table_sql: table_sql) }
+
+    it "should open sqlite db" do
+      allow(SQLite3::Database).to receive(:new).and_call_original
+      CookieExtractor::Common.with_sqlite(db_file) do |db|
+        expect(db).to be_a(SQLite3::Database)
+        row = db.execute("SELECT * FROM test").first
+        expect(row).to be_a(Hash)
+        expect(row["item"]).to eq("item value")
+        expect { db.execute("INSERT INTO test VALUES (2, 'nope')") }.to raise_error(SQLite3::ReadOnlyException)
+      end
+      expected_file = /^file:\/\/\/.+\.sqlite\?immutable=0$/
+      expected_options = { flags: SQLite3::Constants::Open::READONLY | SQLite3::Constants::Open::URI }
+      expect(SQLite3::Database).to have_received(:new).with(expected_file, expected_options)
+    end
+
+    it "retries with immutable=1 when BusyException" do
+      path = db_file
+      db = SQLite3::Database.new(path)
+      db.execute("BEGIN EXCLUSIVE")
+      allow(SQLite3::Database).to receive(:new).and_call_original
+      begin
+        CookieExtractor::Common.with_sqlite(path) do |db|
+          expect(db).to be_a(SQLite3::Database)
+          row = db.execute("SELECT * FROM test").first
+          expect(row).to be_a(Hash)
+          expect(row["item"]).to eq("item value")
+          expect { db.execute("INSERT INTO test VALUES (2, 'nope')") }.to raise_error(SQLite3::ReadOnlyException)
+        end
+      ensure
+        db.close
+      end
+      expect(SQLite3::Database).to have_received(:new).with(%r{immutable=0}, flags: SQLite3::Constants::Open::READONLY | SQLite3::Constants::Open::URI)
+      expect(SQLite3::Database).to have_received(:new).with(%r{immutable=1}, flags: SQLite3::Constants::Open::READONLY | SQLite3::Constants::Open::URI)
+    end
+
+    it "should close the db when finished" do
+      allow(SQLite3::Database).to receive(:new).and_wrap_original do |original_method, *args|
+        db = original_method.call(*args)
+        expect(db).to receive(:close).and_call_original
+        db
+      end
+      expect { CookieExtractor::Common.with_sqlite(db_file) { raise "err" } }.to raise_error("err")
+    end
+
+    it "reads db with relative path" do
+      path = db_file
+      relative = File.basename(path)
+      Dir.chdir(File.dirname(path)) do
+        result = nil
+        CookieExtractor::Common.with_sqlite(relative) do |db|
+          result = db.execute("SELECT * FROM test").first
+        end
+        expect(result["item"]).to eq("item value")
+      end
+    end
+  end
 end

--- a/spec/firefox_cookie_extractor_spec.rb
+++ b/spec/firefox_cookie_extractor_spec.rb
@@ -139,4 +139,60 @@ describe CookieExtractor::FirefoxCookieExtractor do
       expect(result.size).to eq(2)
     end
   end
+
+  describe "with session cookies" do
+    def build_recovery_data(cookies)
+      json = JSON.generate("cookies" => cookies)
+      compressed = LZ4.block_encode(json)
+      header = "mozLz40\0"
+      size = [json.bytesize].pack("V")
+      header + size + compressed
+    end
+
+    let (:recovery_path) { File.dirname('filename') + '/sessionstore-backups/recovery.jsonlz4' }
+    let (:recovery_data) {
+      build_recovery_data([
+        {"host" => ".example.com", "path" => "/", "secure" => true, "name" => "SESSION", "value" => "SESSION VALUE"},
+        {"host" => "another.example.org", "path" => "/", "secure" => true, "name" => "SESSION2", "value" => "SESSION2 VALUE"}
+      ])
+    }
+
+    before :each do
+      allow(CookieExtractor::Common).to receive(:with_sqlite).with('filename').and_yield(@fake_cookie_db)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:read).and_call_original
+      expect(@fake_cookie_db).to receive(:get_first_value).and_return(16)
+      expect(@fake_cookie_db).to receive(:execute).and_yield(
+        {'host' => '.dallien.net', 'path' => '/', 'isSecure' => '0', 'expiry' => '1234567890', 'name' => 'PERSISTENT', 'value' => 'PERSISTENT VALUE'}
+      )
+    end
+
+    it "returns persistent + session cookies" do
+      allow(File).to receive(:exist?).with(recovery_path).and_return(true)
+      allow(File).to receive(:read).with(recovery_path).and_return(recovery_data)
+      extractor = CookieExtractor::FirefoxCookieExtractor.new('filename')
+      result = extractor.extract(format: :hash)
+      expect(result.size).to eq(3)
+      expect(result.first).to eq({domain: ".dallien.net", expires: 1234567, name: "PERSISTENT", path: "/", secure: false, value: "PERSISTENT VALUE"})
+      expect(result.last).to eq({domain: "another.example.org", expires: 0, name: "SESSION2", path: "/", secure: true, value: "SESSION2 VALUE"})
+    end
+
+    it "filters session cookies by domain" do
+      allow(File).to receive(:exist?).with(recovery_path).and_return(true)
+      allow(File).to receive(:read).with(recovery_path).and_return(recovery_data)
+      extractor = CookieExtractor::FirefoxCookieExtractor.new('filename')
+      result = extractor.extract(domain: ".example.org", format: :hash)
+      expect(result).to eq([{domain: "another.example.org", expires: 0, name: "SESSION2", path: "/", secure: true, value: "SESSION2 VALUE"}])
+    end
+
+    it "returns only persistent when recovery file missing" do
+      allow(File).to receive(:exist?).with(recovery_path).and_return(false)
+      expect(File).not_to receive(:read).with(recovery_path)
+
+      extractor = CookieExtractor::FirefoxCookieExtractor.new('filename')
+      result = extractor.extract(format: :hash)
+      expect(result.size).to eq(1)
+      expect(result.first[:value]).to eq("PERSISTENT VALUE")
+    end
+  end
 end

--- a/spec/firefox_cookie_extractor_spec.rb
+++ b/spec/firefox_cookie_extractor_spec.rb
@@ -2,31 +2,9 @@ require File.join(File.dirname(__FILE__), "spec_helper")
 
 describe CookieExtractor::FirefoxCookieExtractor do
   before :each do
-    @fake_cookie_db = double("cookie database",
-      :results_as_hash= => true,
-      :close => true)
-    expect(SQLite3::Database).to receive(:new).
-      with('filename').
-        and_return(@fake_cookie_db)
-  end
-
-  describe "opening and closing a sqlite db" do
-    before :each do
-      expect(@fake_cookie_db).to receive(:get_first_value).and_return(15)
-      expect(@fake_cookie_db).to receive(:execute).and_yield(
-        {'host' => '.dallien.net',
-          'path' => '/',
-          'isSecure' => '0',
-          'expiry' => '1234567890',
-          'name' => 'NAME',
-          'value' => 'VALUE'})
-      @extractor = CookieExtractor::FirefoxCookieExtractor.new('filename')
-    end
-
-    it "should close the db when finished" do
-      expect(@fake_cookie_db).to receive(:close)
-      @extractor.extract
-    end
+    @fake_cookie_db = double("cookie database")
+    allow(CookieExtractor::Common).to receive(:with_sqlite).and_call_original
+    allow(CookieExtractor::Common).to receive(:with_sqlite).with('filename').and_yield(@fake_cookie_db)
   end
 
   describe "with a cookie that has a host starting with a dot" do
@@ -147,7 +125,6 @@ describe CookieExtractor::FirefoxCookieExtractor do
         block.call({'host' => '.other.test', 'path' => '/', 'isSecure' => '0', 'expiry' => '1787601234000', 'name' => 'NAME2', 'value' => 'OTHER VALUE'})
       end
       @extractor = CookieExtractor::FirefoxCookieExtractor.new('filename')
-      allow(@fake_cookie_db).to receive(:close)
     end
 
     it "returns correct domain" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,34 @@
 require 'time'
+require 'tmpdir'
+require 'sqlite3'
+
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "cookie_extractor"))
 
+module Helpers
+  def create_sqlite_db(rows, table_name:, table_sql:)
+    @files ||= []
+    path = Dir::Tmpname.create(["cookie_extractor_testdb", ".sqlite"]) {}
+    @files << path
+    db = SQLite3::Database.new(path)
+    table_sql.split(";").map(&:strip).reject(&:empty?).each do |statement|
+      db.execute(statement)
+    end
+    rows.each do |row|
+      placeholders = (["?"] * row.size).join(", ")
+      db.execute("INSERT INTO #{table_name} VALUES (#{placeholders})", row)
+    end
+    path
+  ensure
+    db&.close
+  end
+end
+
+RSpec.configure do |config|
+  config.include Helpers
+
+  config.after(:each) do
+    @files&.each do |path|
+      File.delete(path) if File.exist?(path)
+    end
+  end
+end


### PR DESCRIPTION
Currently there are 2 issues for Firefox:
1. `cookies.sqlite` can't be opened if Firefox is open (`database is locked: (SQLite3::BusyException)`)
2. Firefox stores session cookies in `sessionstore-backups/recovery.jsonlz4` (saved every couple of seconds) and not in  `cookies.sqlite`

This PR fixes these issues so cookies are perfectly extracted from Firefox on Linux with latest Firefox (v153).

PS. When merging, don't squash commits because they're independent changes.
