### PR TITLE
Increase Firefox recovery file LZ4 max_dest_size

### DIFF
--- a/lib/cookie_extractor/firefox_cookie_extractor.rb
+++ b/lib/cookie_extractor/firefox_cookie_extractor.rb
@@ -36,15 +36,16 @@ module CookieExtractor
     def session_cookies(format:, domain:)
       return [] unless @recovery_file
       data = file_binread(@recovery_file)
-      if data[0..7] == "mozLz40\0"
-         json = LZ4.block_decode(data[12..-1])
-         recovery = JSON.parse(json)
-         recovery['cookies'].to_a.filter_map do |cookie|
-           next unless domain.nil? || cookie_applies?(cookie['host'], domain)
-           cookie_line(cookie['host'], cookie['path'], !!cookie['secure'], 0, cookie['name'], cookie['value'], format: format)
-         end
-      else
-        []
+      return [] if data.bytesize <= 12 || data.byteslice(0, 8) != "mozLz40\0"
+
+      uncompressed_size = data.byteslice(8, 4).unpack1("V")
+      compressed = data.byteslice(12, data.bytesize - 12)
+      max_dest_size = [uncompressed_size, 100 * 1024 * 1024].min
+      json = LZ4.block_decode(compressed, max_dest_size)
+      recovery = JSON.parse(json)
+      recovery['cookies'].to_a.filter_map do |cookie|
+        next unless domain.nil? || cookie_applies?(cookie['host'], domain)
+        cookie_line(cookie['host'], cookie['path'], !!cookie['secure'], 0, cookie['name'], cookie['value'], format: format)
       end
     end
 


### PR DESCRIPTION
Encountered issue with Firefox where `recovery.jsonlz4` is too big (1+ MiB) and failed with:
```
/usr/lib/ruby/gems/3.4.0/gems/extlz4-0.3.5/lib/extlz4.rb:285:in 'LZ4::BlockDecoder.decode': failed LZ4_decompress_safe - max_dest_size is too small, or data is corrupted (LZ4::Error)
    from /usr/lib/ruby/gems/3.4.0/gems/extlz4-0.3.5/lib/extlz4.rb:285:in 'LZ4.block_decode'
    from lib/cookie_extractor/firefox_cookie_extractor.rb:41:in 'CookieExtractor::FirefoxCookieExtractor#session_cookies'
    from lib/cookie_extractor/firefox_cookie_extractor.rb:17:in 'CookieExtractor::FirefoxCookieExtractor#extract'
```

This PR fixes this issue by increasing `max_dest_size` to 100 MiB.
`recovery.jsonlz4`  with 1 MiB decompresses to around 5 MiB so this should be plenty for even biggest cases.
