### PR TITLE
Chrome fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     cookie_extractor (0.2.0)
       extlz4 (~> 0.3)
+      ruby-dbus (~> 0.25)
       sqlite3 (~> 2.9)
 
 GEM
@@ -10,7 +11,9 @@ GEM
   specs:
     diff-lcs (1.6.2)
     extlz4 (0.3.5)
+    logger (1.7.0)
     mini_portile2 (2.8.9)
+    rexml (3.4.4)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -24,6 +27,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
+    ruby-dbus (0.25.0)
+      logger
+      rexml
     sqlite3 (2.9.6)
       mini_portile2 (~> 2.8.0)
 

--- a/bin/cookie_extractor
+++ b/bin/cookie_extractor
@@ -8,16 +8,37 @@ def usage msg=nil
   puts "Usage: cookie_extractor /path/to/cookies.sqlite              Open a DB file"
   puts "       cookie_extractor --guess                              Guess which browser to use and open corresponding file"
   puts "       cookie_extractor --browser chrome|chromium|firefox    Open DB corresponding to a particular browser"
+  puts "                        [--secret SECRET]                    Provide secret for cookie decryption (can be repeated for multiple)"
   exit
 end
 
+secrets = []
+i = 0
+while i < ARGV.length
+  arg = ARGV[i]
+  if arg == '--secret' || arg == '-s'
+    secret = ARGV[i + 1]
+    abort "Error: --secret requires an argument" if secret.nil? || secret.start_with?('-')
+    secrets << secret
+    ARGV.delete_at(i)
+    ARGV.delete_at(i)
+    next
+  elsif arg.start_with?('--secret=')
+    secret = arg.split('=', 2)[1]
+    abort "Error: --secret requires an argument" if secret.nil? || secret.empty?
+    secrets << secret
+    ARGV.delete_at(i)
+    next
+  end
+  i += 1
+end
 
 begin
   extractor =
     case ARGV.first
     when '--guess', '-g'
       begin
-        CookieExtractor::BrowserDetector.guess()
+        CookieExtractor::BrowserDetector.guess(secrets: secrets)
       rescue CookieExtractor::NoCookieFileFoundException
         abort "Error: we couldn't find any supported browser's cookies"
       end
@@ -25,7 +46,7 @@ begin
       browser = ARGV[1]
       usage "Error: Please supply a browser name" unless browser
       begin
-        CookieExtractor::BrowserDetector.browser_extractor(browser)
+        CookieExtractor::BrowserDetector.browser_extractor(browser, secrets: secrets)
       rescue CookieExtractor::InvalidBrowserNameException
         abort "Error: '#{browser}' is not a valid browser name"
       rescue CookieExtractor::NoCookieFileFoundException
@@ -36,7 +57,7 @@ begin
     else
       filename = ARGV.first
       abort "Error: #{filename} does not exist" unless File.exist?(filename)
-      CookieExtractor::BrowserDetector.new_extractor(filename)
+      CookieExtractor::BrowserDetector.new_extractor(filename, secrets: secrets)
     end
   puts extractor.extract.join("\n")
 rescue SQLite3::NotADatabaseException,

--- a/cookie_extractor.gemspec
+++ b/cookie_extractor.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.13"
   s.add_runtime_dependency "sqlite3", "~> 2.9"
   s.add_runtime_dependency "extlz4", "~> 0.3"
+  s.add_runtime_dependency "ruby-dbus", "~> 0.25"
+
 end

--- a/lib/cookie_extractor/browser_detector.rb
+++ b/lib/cookie_extractor/browser_detector.rb
@@ -6,8 +6,8 @@ module CookieExtractor
   class NoCookieFileFoundException < Exception; end
 
   class BrowserDetector
-    CHROMIUM_BROWSERS = %w[chrome chromium].freeze
-    SUPPORTED_BROWSERS = (CHROMIUM_BROWSERS + %w[firefox]).freeze
+    CHROMIUM_APPS = %w[chrome chromium].freeze
+    SUPPORTED_APPS = (CHROMIUM_APPS + %w[firefox]).freeze
 
     # Returns the extractor of the most recently used browser's cookies
     #   or raise NoCookieFileFoundException if there are no cookies
@@ -26,9 +26,9 @@ module CookieExtractor
     end
 
     # Open a browser's cookie file using intelligent guesswork
-    def self.browser_extractor(browser, path = nil)
-      raise InvalidBrowserNameException, "Browser must be one of: #{self.supported_browsers.join(', ')}" unless browser.nil? || self.supported_browsers.include?(browser)
-      paths = path.nil? ? most_recently_used(cookie_locations(browser)) : [path]
+    def self.browser_extractor(app, path = nil)
+      raise InvalidBrowserNameException, "App/Browser must be one of: #{self.supported_apps.join(', ')}" unless app.nil? || self.supported_apps.include?(app)
+      paths = path.nil? ? most_recently_used(cookie_locations(app)) : [path]
       if paths.length < 1 or not File.exist?(paths.first)
         raise NoCookieFileFoundException, "File #{paths.first} does not exist!"
       end
@@ -44,8 +44,8 @@ module CookieExtractor
       end
     end
 
-    def self.supported_browsers
-      SUPPORTED_BROWSERS
+    def self.supported_apps
+      SUPPORTED_APPS
     end
 
     def self.detect_browser(db_filename)
@@ -65,12 +65,12 @@ module CookieExtractor
       db.table_info(table_name).size > 0
     end
 
-    def self.cookie_locations(browser = nil)
-      browsers = browser.nil? ? supported_browsers : [browser]
+    def self.cookie_locations(app = nil)
+      apps = app.nil? ? supported_apps : [app]
       locations = []
-      locations << "~/.config/google-chrome/Default/Cookies" if browsers.include?("chrome")
-      locations << "~/.config/chromium/Default/Cookies" if browsers.include?("chromium")
-      if browsers.include?("firefox")
+      locations << "~/.config/google-chrome/Default/Cookies" if apps.include?("chrome")
+      locations << "~/.config/chromium/Default/Cookies" if apps.include?("chromium")
+      if apps.include?("firefox")
         locations << "~/.mozilla/firefox/*.*default*/cookies.sqlite"
         locations << "~/.mozilla/firefox/*.Profile*/cookies.sqlite"
       end

--- a/lib/cookie_extractor/browser_detector.rb
+++ b/lib/cookie_extractor/browser_detector.rb
@@ -11,10 +11,10 @@ module CookieExtractor
 
     # Returns the extractor of the most recently used browser's cookies
     #   or raise NoCookieFileFoundException if there are no cookies
-    def self.guess
+    def self.guess(secrets: [])
       most_recently_used_detected_browsers.each { |path|
         begin
-          extractor = self.browser_extractor(nil, path)
+          extractor = self.browser_extractor(nil, path: path, secrets: secrets)
         rescue BrowserNotDetectedException, NoCookieFileFoundException
           # better try the next one...
         else
@@ -26,19 +26,20 @@ module CookieExtractor
     end
 
     # Open a browser's cookie file using intelligent guesswork
-    def self.browser_extractor(app, path = nil)
+    def self.browser_extractor(app, path: nil, secrets: [])
       raise InvalidBrowserNameException, "App/Browser must be one of: #{self.supported_apps.join(', ')}" unless app.nil? || self.supported_apps.include?(app)
       paths = path.nil? ? most_recently_used(cookie_locations(app)) : [path]
       if paths.length < 1 or not File.exist?(paths.first)
         raise NoCookieFileFoundException, "File #{paths.first} does not exist!"
       end
-      self.new_extractor(paths.first)
+      self.new_extractor(paths.first, app: app, secrets: secrets)
     end
 
-    def self.new_extractor(db_filename)
+    def self.new_extractor(db_filename, app: nil, secrets: [])
       browser = detect_browser(db_filename)
       if browser
-        CookieExtractor.const_get("#{browser}CookieExtractor").new(db_filename)
+        app = detect_app(db_filename) unless app
+        CookieExtractor.const_get("#{browser}CookieExtractor").new(db_filename, app: app, secrets: secrets)
       else
         raise BrowserNotDetectedException, "Could not detect browser type."
       end
@@ -59,6 +60,20 @@ module CookieExtractor
           end
       end
       browser
+    end
+
+    def self.detect_app(db_filename)
+      case db_filename.split('/')[-3]
+      when 'firefox'
+        :firefox
+      when 'google-chrome'
+        :chrome
+      when 'chromium'
+        :chromium
+      else
+        # Unknown so fallback as chromium
+        :chromium
+      end
     end
 
     def self.has_table?(db, table_name)

--- a/lib/cookie_extractor/chrome_cookie_decryptor.rb
+++ b/lib/cookie_extractor/chrome_cookie_decryptor.rb
@@ -1,0 +1,168 @@
+require 'openssl'
+require_relative 'secret_service'
+
+module CookieExtractor
+
+  # Reference:
+  # * https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/os_crypt/async/browser/os_crypt_async.cc
+  # * https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/os_crypt/async/common/encryptor.cc
+  class ChromeCookieDecryptor
+
+    def initialize(app: nil, secrets: [])
+      app = :chrome unless app
+      @providers = []
+      @providers << V10KeyProvider.new(secrets: secrets)
+      @providers << SecretKeyProvider.new(app, secrets: secrets)
+      @providers << SecretPortalKeyProvider.new(app, secrets: secrets)
+    end
+
+    def decrypt(data, &block)
+      @providers.each do |provider|
+        value = provider.decrypt(data, &block)
+        return value unless value.nil?
+      end
+      raise "Don't know how to decrypt '#{data.byteslice(0, 3)}'"
+    end
+
+    class KeyProvider
+      SALT = 'saltysalt'.freeze
+      ALGORITHM = 'AES-128-CBC'
+      KEY_LENGTH = 16
+      IV = ' ' * 16
+
+      def initialize(secrets: [])
+        @custom_secrets = secrets
+      end
+
+      def decrypt(data, &block)
+        if data.start_with?(self.class::TAG)
+          tag_length = self.class::TAG.length
+          ciphertext = data.byteslice(tag_length, data.bytesize - tag_length)
+          custom_keys.each do |key|
+            value = decrypt_value(ciphertext, key)
+            next if value.nil?
+            next if block_given? && !yield(value)
+            return value
+          end
+          keys.each do |key|
+            value = decrypt_value(ciphertext, key)
+            next if value.nil?
+            next if block_given? && !yield(value)
+            return value
+          end
+          raise "Failed to decrypt Chrome #{self.class::TAG} cookie!"
+        else
+          nil
+        end
+      end
+
+      def decrypt_value(ciphertext, key)
+        cipher = OpenSSL::Cipher.new(self.class::ALGORITHM)
+        cipher.decrypt
+        cipher.key = key
+        cipher.iv = self.class::IV
+        cipher.update(ciphertext) + cipher.final
+      rescue OpenSSL::Cipher::CipherError
+        # wrong key
+      end
+
+      def secret_key(secret)
+        pbkdf2(secret, 1)
+      end
+
+      def custom_keys
+        @custom_keys ||= @custom_secrets.map { |secret| secret_key(secret) }
+      end
+
+      def keys
+        @keys ||= secrets.map { |secret| secret_key(secret) }
+      end
+
+      def secrets
+        raise NotImplementedError.new("Unimplemented Chrome #{self.class.name.split('::').last} #{self.class::TAG}")
+      end
+
+      def pbkdf2(secret, iterations)
+        OpenSSL::KDF.pbkdf2_hmac(secret, salt: SALT, iterations: iterations, length: KEY_LENGTH, hash: OpenSSL::Digest::SHA1.new)
+      end
+
+      def encrypt(plaintext, secret)
+        self.class::TAG + encrypt_value(plaintext, secret_key(secret))
+      end
+
+      def encrypt_value(plaintext, key)
+        cipher = OpenSSL::Cipher.new(self.class::ALGORITHM)
+        cipher.encrypt
+        cipher.key = key
+        cipher.iv = self.class::IV
+        cipher.update(plaintext) + cipher.final
+      end
+    end
+
+    # https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/os_crypt/async/browser/posix_key_provider.cc
+    class V10KeyProvider < KeyProvider
+      TAG = "v10"
+      def secrets
+        ["peanuts"]
+      end
+
+      def encrypt(plaintext)
+        super(plaintext, secrets.first)
+      end
+    end
+
+    # https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/os_crypt/async/browser/freedesktop_secret_key_provider.cc
+    class SecretKeyProvider < KeyProvider
+      TAG = "v11"
+      def initialize(app, secrets: [], secret_service: nil)
+        super(secrets: secrets)
+        @app = app
+        @secret_service = secret_service
+      end
+
+      def secret_service
+        @secret_service ||= SecretService.new
+      end
+
+      def secrets
+        secrets = []
+        items = [
+          { "user" => key_name(@app) },  # KDE / KWallet
+          { "application" => @app.to_s } # GNOME etc
+        ]
+        items.each do |attrs|
+          secrets += secret_service.secrets(attrs)
+        end
+        raise "Failed to find secret #{items.flat_map.map(&:values).join(' / ')}" if secrets.empty?
+        secrets
+      end
+
+      def key_name(app)
+        case app.to_sym
+        when :chrome
+          "Chrome Safe Storage"
+        when :chromium
+          "Chromium Safe Storage"
+        else
+          # Fallback
+          "Chromium Safe Storage"
+        end
+      end
+    end
+
+    # https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/os_crypt/async/browser/secret_portal_key_provider.cc
+    class SecretPortalKeyProvider < KeyProvider
+      TAG = "v12"
+      def initialize(app, secrets: [])
+        super(secrets: secrets)
+        @app = app
+      end
+
+      def secrets
+        # TODO
+        super
+      end
+    end
+
+  end
+end

--- a/lib/cookie_extractor/chrome_cookie_extractor.rb
+++ b/lib/cookie_extractor/chrome_cookie_extractor.rb
@@ -15,10 +15,23 @@ module CookieExtractor
           next unless domain.nil? || cookie_applies?(row['host_key'], domain)
 
           secure = row.key?('is_secure') ? row['is_secure'] : row['secure']
-          result << cookie_line(row['host_key'], row['path'], secure, row['expires_utc'], row['name'], row['value'], format: format)
+          expires = expires_unix(row['expires_utc'])
+          result << cookie_line(row['host_key'], row['path'], secure, expires, row['name'], row['value'], format: format)
         end
       end
       result
     end
+
+    private
+
+    # Chrome stores expiry as microseconds (s/1,000,000) since the Windows epoch (1601-01-01 00:00:00 UTC)
+    #
+    # https://chromium.googlesource.com/chromium/src/+/refs/heads/main/base/time/time.h
+    def expires_unix(expires_utc)
+      expires = expires_utc.to_i
+      return 0 if expires == 0
+      expires / 1_000_000 - 11_644_473_600
+    end
+
   end
 end

--- a/lib/cookie_extractor/chrome_cookie_extractor.rb
+++ b/lib/cookie_extractor/chrome_cookie_extractor.rb
@@ -1,22 +1,27 @@
+require 'digest'
 require_relative 'common'
+require_relative 'chrome_cookie_decryptor'
 
 module CookieExtractor
   class ChromeCookieExtractor
     include Common
 
-    def initialize(cookie_file)
+    def initialize(cookie_file, app: nil, secrets: [])
       @cookie_file = cookie_file
+      @decryptor = ChromeCookieDecryptor.new(app: app, secrets: secrets)
     end
 
     def extract(format: :netscape, domain: nil)
       result = []
       with_sqlite(@cookie_file) do |db|
+        version = db.get_first_value("SELECT value FROM meta WHERE key = 'version'").to_i
         db.execute("SELECT * FROM cookies") do |row|
           next unless domain.nil? || cookie_applies?(row['host_key'], domain)
 
           secure = row.key?('is_secure') ? row['is_secure'] : row['secure']
           expires = expires_unix(row['expires_utc'])
-          result << cookie_line(row['host_key'], row['path'], secure, expires, row['name'], row['value'], format: format)
+          value = decrypt_value(row, version)
+          result << cookie_line(row['host_key'], row['path'], secure, expires, row['name'], value, format: format)
         end
       end
       result
@@ -31,6 +36,30 @@ module CookieExtractor
       expires = expires_utc.to_i
       return 0 if expires == 0
       expires / 1_000_000 - 11_644_473_600
+    end
+
+    def decrypt_value(row, version)
+      value = row['value']
+      encrypted_value = row['encrypted_value'].to_s
+      unless encrypted_value.empty?
+        value = @decryptor.decrypt(encrypted_value) do |decrypted_value|
+          valid_value?(decrypted_value, version, row['host_key'])
+        end
+        if version >= 24
+          # https://chromium.googlesource.com/chromium/src/+/refs/heads/main/net/extras/sqlite/sqlite_persistent_cookie_store.cc
+          # 24+ version prepends SHA256 hash of host_key
+          value = value.byteslice(32, value.bytesize - 32)
+        end
+      end
+      value
+    end
+
+    def valid_value?(decrypted_value, version, host_key)
+      if version >= 24
+        decrypted_value.byteslice(0, 32) == Digest::SHA256.digest(host_key)
+      else
+        decrypted_value.ascii_only?
+      end
     end
 
   end

--- a/lib/cookie_extractor/firefox_cookie_extractor.rb
+++ b/lib/cookie_extractor/firefox_cookie_extractor.rb
@@ -7,7 +7,7 @@ module CookieExtractor
   class FirefoxCookieExtractor
     include Common
 
-    def initialize(cookie_file)
+    def initialize(cookie_file, app: nil, secrets: [])
       @cookie_file = cookie_file
       @recovery_file = File.dirname(@cookie_file) + '/sessionstore-backups/recovery.jsonlz4'
       @recovery_file = nil unless File.exist?(@recovery_file)

--- a/lib/cookie_extractor/secret_service.rb
+++ b/lib/cookie_extractor/secret_service.rb
@@ -1,0 +1,73 @@
+require 'dbus'
+require 'timeout'
+require 'json'
+
+module CookieExtractor
+  class SecretService
+
+    # https://specifications.freedesktop.org/secret-service/latest/
+    SECRETS_SERVICE   = "org.freedesktop.secrets"
+    SECRETS_PATH      = "/org/freedesktop/secrets"
+    SERVICE_INTERFACE = "org.freedesktop.Secret.Service"
+    PROMPT_INTERFACE  = "org.freedesktop.Secret.Prompt"
+
+    class Error < RuntimeError; end
+    class TimeoutError < Error; end
+
+    def initialize(timeout: 60)
+      @timeout = timeout
+      @bus = DBus.session_bus
+    end
+
+    def secrets(attributes)
+      Timeout.timeout(@timeout) do
+        service = @bus.service(SECRETS_SERVICE).object(SECRETS_PATH)[SERVICE_INTERFACE]
+
+        output, session_path = service.OpenSession("plain", []) # algorithm, input
+
+        unlocked, locked = service.SearchItems(attributes)
+
+        unless locked.empty?
+          unlocked2, prompt_path = service.Unlock(locked)
+          if prompt_path != "/"
+            dismissed, unlocked3 = show_prompt(prompt_path, attributes)
+            unlocked2 += unlocked3
+          end
+          unlocked += unlocked2
+        end
+        return [] if unlocked.empty?
+
+        read_secrets = service.GetSecrets(unlocked, session_path).first
+
+        return read_secrets.values.map { |secret| secret[2].pack("C*") }.uniq # session, parameters, [value], content_type
+      end
+    rescue DBus::Error
+      raise Error.new("Failed to get secret from Secret Service!")
+    rescue Timeout::Error
+      raise TimeoutError.new("Timeout while waiting for Secret Service")
+    end
+
+    def show_prompt(prompt_path, attributes)
+      prompt = @bus.service(SECRETS_SERVICE).object(prompt_path)[PROMPT_INTERFACE]
+      prompt.Prompt("") # window-id
+      wait_for_signal(prompt, "Completed")
+    rescue Timeout::Error
+      raise TimeoutError.new("Timeout while waiting for secret unlock => #{attributes.to_json}")
+    end
+
+    def wait_for_signal(interface, signal_name)
+      main = DBus::Main.new
+      main << @bus
+
+      result = nil
+      interface.on_signal(signal_name) do |*args|
+        result = args
+        main.quit
+      end
+
+      Timeout.timeout(@timeout / 2) { main.run }
+      result
+    end
+
+  end
+end

--- a/spec/browser_detector_spec.rb
+++ b/spec/browser_detector_spec.rb
@@ -94,7 +94,7 @@ describe CookieExtractor::BrowserDetector, "guessing the location of the cookie 
         chrome_path = File.expand_path(CookieExtractor::BrowserDetector.cookie_locations("chrome").first)
         expect(CookieExtractor::BrowserDetector).
           to receive(:browser_extractor).
-            once.with(nil, chrome_path)
+            once.with(nil, path: chrome_path, secrets: [])
         CookieExtractor::BrowserDetector.guess
       end
     end

--- a/spec/chrome_cookie_extractor_spec.rb
+++ b/spec/chrome_cookie_extractor_spec.rb
@@ -1,8 +1,44 @@
 require File.join(File.dirname(__FILE__), "spec_helper")
 
+def update_value(host_key, value, version = 24)
+  version >= 24 ? Digest::SHA256.digest(host_key) + value : value
+end
+
+def encrypt_v10(plaintext)
+  CookieExtractor::ChromeCookieDecryptor::V10KeyProvider.new.encrypt(plaintext)
+end
+
+def encrypt_v11(plaintext, secret)
+  CookieExtractor::ChromeCookieDecryptor::SecretKeyProvider.new('chrome').encrypt(plaintext, secret)
+end
+
 describe CookieExtractor::ChromeCookieExtractor do
+
+  let(:cookies_sql) do
+    <<-SQL
+    CREATE TABLE cookies(
+      host_key TEXT NOT NULL,
+      name TEXT NOT NULL,
+      value TEXT NOT NULL,
+      encrypted_value BLOB NOT NULL,
+      path TEXT NOT NULL,
+      expires_utc INTEGER NOT NULL,
+      is_secure INTEGER NOT NULL
+    );
+    SQL
+  end
+
+  let(:meta_sql) { "CREATE TABLE meta(key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);" }
+
+  def cookie_db(rows, version: 24, schema_sql: nil)
+    sql = schema_sql || cookies_sql
+    create_sqlite_db(rows, table_name: "cookies", table_sql: "#{sql}; #{meta_sql}") do |db|
+      db.execute("INSERT INTO meta (key, value) VALUES ('version', ?)", version)
+    end
+  end
+
   before :each do
-    @fake_cookie_db = double("cookie database")
+    @fake_cookie_db = double("cookie database", :get_first_value => 23)
     allow(CookieExtractor::Common).to receive(:with_sqlite).and_call_original
     allow(CookieExtractor::Common).to receive(:with_sqlite).with('filename').and_yield(@fake_cookie_db)
   end
@@ -144,4 +180,60 @@ describe CookieExtractor::ChromeCookieExtractor do
       expect(result.map {|r| r[:expires]}).to eq([1799168628, 1785521393])
     end
   end
+
+  describe "with unencrypted cookie" do
+    let(:db_path) { cookie_db([["example.org", "NAME", "VALUE", "", "/", 12_879_041_490_000_000, 1]]) }
+
+    it "returns cookie data" do
+      expect(described_class.new(db_path).extract(format: :hash)).to eq([
+        { domain: "example.org", path: "/", secure: true, expires: 1234567890, name: "NAME", value: "VALUE" }
+      ])
+    end
+  end
+
+  describe "with encrypted cookies" do
+    let(:db_path) {
+      cookie_db([
+        ["example.org", "cookie1", "", encrypt_v10(update_value("example.org", "value1")), "/", 0, 0],
+        [".example.com", "cookie2", "", encrypt_v11(update_value(".example.com", "value2"), "test-secret"), "/", 0, 1],
+        ["extra.example.com", "cookie3", "", encrypt_v11(update_value("extra.example.com", "value3"), "custom2secret2"), "/", 0, 1]
+      ])
+    }
+
+    it "decrypts not using SecretService when --secret specified" do
+      secret_service = instance_double(CookieExtractor::SecretService)
+      expect(secret_service).not_to receive(:secrets)
+      allow(CookieExtractor::SecretService).to receive(:new).and_return(secret_service)
+
+      db_path = cookie_db([["diff.example.com", "cookie4", "", encrypt_v11(update_value("diff.example.com", "value4"), "custom 4 secret"), "/", 0, 0]])
+      extractor = described_class.new(db_path, secrets: ["custom 4 secret"])
+
+      expect(extractor.extract(format: :hash)).to eq([
+        {domain: "diff.example.com", expires: 0, name: "cookie4", path: "/", secure: false, value: "value4"}
+      ])
+    end
+
+    it "decrypts all cookies" do
+      secret_service = instance_double(CookieExtractor::SecretService)
+      expect(secret_service).to receive(:secrets).with({ "user" => "Chrome Safe Storage" }).and_return([]).once
+      expect(secret_service).to receive(:secrets).with({ "application" => "chrome" }).and_return(["test-secret"]).once
+      expect(CookieExtractor::SecretService).to receive(:new).and_return(secret_service).at_least(:once)
+
+      expect(described_class.new(db_path, app: "chrome", secrets: ["custom2secret2"]).extract(format: :hash)).to eq([
+        {domain: "example.org", expires: 0, name: "cookie1", path: "/", secure: false, value: "value1"},
+        {domain: ".example.com", expires: 0, name: "cookie2", path: "/", secure: true, value: "value2"},
+        {domain: "extra.example.com", expires: 0, name: "cookie3", path: "/", secure: true, value: "value3"}
+      ])
+    end
+
+    it "decrypts old cookies" do
+      version = 23
+      db_path = cookie_db([["old.example.com", "cookie5", "", encrypt_v10(update_value(nil, "value5", version)), "/", 0, 0]], version: version)
+
+      expect(described_class.new(db_path).extract(format: :hash)).to eq([
+        {domain: "old.example.com", expires: 0, name: "cookie5", path: "/", secure: false, value: "value5"}
+      ])
+    end
+  end
+
 end

--- a/spec/chrome_cookie_extractor_spec.rb
+++ b/spec/chrome_cookie_extractor_spec.rb
@@ -13,7 +13,7 @@ describe CookieExtractor::ChromeCookieExtractor do
         { 'host_key' => '.dallien.net',
           'path' => '/',
           'secure' => '0',
-          'expires_utc' => '1234567890',
+          'expires_utc' => 12_879_041_490_000_000,
           'name' => 'NAME',
           'value' => 'VALUE'})
       @extractor = CookieExtractor::ChromeCookieExtractor.new('filename')
@@ -42,7 +42,7 @@ describe CookieExtractor::ChromeCookieExtractor do
         { 'host_key' => 'jeff.dallien.net',
           'path' => '/path',
           'secure' => '1',
-          'expires_utc' => '1234567890',
+          'expires_utc' => 12_879_041_490_000_000,
           'name' => 'NAME',
           'value' => 'VALUE'})
       @extractor = CookieExtractor::ChromeCookieExtractor.new('filename')
@@ -71,7 +71,7 @@ describe CookieExtractor::ChromeCookieExtractor do
         { 'host_key' => '.dallien.net',
           'path' => '/',
           'secure' => '0',
-          'expires_utc' => '1234567890',
+          'expires_utc' => 12_879_041_490_000_000,
           'name' => 'NAME',
           'value' => 'VALUE'})
       @extractor = CookieExtractor::ChromeCookieExtractor.new('filename')
@@ -90,7 +90,7 @@ describe CookieExtractor::ChromeCookieExtractor do
         { 'host_key' => '.dallien.net',
           'path' => '/',
           'secure' => '1',
-          'expires_utc' => '1234567890',
+          'expires_utc' => 12_879_041_490_000_000,
           'name' => 'NAME',
           'value' => 'VALUE'})
       @extractor = CookieExtractor::ChromeCookieExtractor.new('filename')
@@ -109,7 +109,7 @@ describe CookieExtractor::ChromeCookieExtractor do
         { 'host_key' => '.dallien.net',
           'path' => '/',
           'is_secure' => '1',
-          'expires_utc' => '1234567890',
+          'expires_utc' => 12_879_041_490_000_000,
           'name' => 'NAME',
           'value' => 'VALUE'})
       @extractor = CookieExtractor::ChromeCookieExtractor.new('filename')
@@ -125,8 +125,8 @@ describe CookieExtractor::ChromeCookieExtractor do
   describe "with domain filter" do
     before :each do
       expect(@fake_cookie_db).to receive(:execute) do |&block|
-        block.call({'host_key' => '.example.com', 'path' => '/', 'is_secure' => '0', 'expires_utc' => '1787601234000', 'name' => 'NAME', 'value' => 'EXAMPLE VALUE'})
-        block.call({'host_key' => '.other.test', 'path' => '/', 'is_secure' => '0', 'expires_utc' => '1787601234000', 'name' => 'NAME2', 'value' => 'OTHER VALUE'})
+        block.call({'host_key' => '.example.com', 'path' => '/', 'is_secure' => '0', 'expires_utc' => 13_443_642_228_769_329, 'name' => 'NAME', 'value' => 'EXAMPLE VALUE'})
+        block.call({'host_key' => '.other.test', 'path' => '/', 'is_secure' => '0', 'expires_utc' => 13_429_994_993_015_941, 'name' => 'NAME2', 'value' => 'OTHER VALUE'})
       end
       @extractor = CookieExtractor::ChromeCookieExtractor.new('filename')
     end
@@ -135,11 +135,13 @@ describe CookieExtractor::ChromeCookieExtractor do
       result = @extractor.extract(domain: "example.com", format: :hash)
       expect(result.size).to eq(1)
       expect(result.first[:value]).to eq("EXAMPLE VALUE")
+      expect(result.first[:expires]).to eq(1799168628)
     end
 
     it "returns all when domain is nil" do
       result = @extractor.extract(format: :hash)
       expect(result.size).to eq(2)
+      expect(result.map {|r| r[:expires]}).to eq([1799168628, 1785521393])
     end
   end
 end

--- a/spec/secret_service_spec.rb
+++ b/spec/secret_service_spec.rb
@@ -1,0 +1,71 @@
+require_relative "spec_helper"
+
+describe CookieExtractor::SecretService do
+  let(:bus) { double("bus") }
+  let(:secrets_service) { double("secrets_service") }
+  let(:secrets_object) { double("secrets_object") }
+  let(:service) { double("service") }
+  let(:prompt_object) { double("prompt_object") }
+  let(:prompt_interface) { double("prompt_interface") }
+
+  before do
+    allow(DBus).to receive(:session_bus).and_return(bus)
+    allow(bus).to receive(:service).with(described_class::SECRETS_SERVICE).and_return(secrets_service)
+    allow(secrets_service).to receive(:object).with(described_class::SECRETS_PATH).and_return(secrets_object)
+    allow(secrets_object).to receive(:[]).with(described_class::SERVICE_INTERFACE).and_return(service)
+  end
+
+  describe "#secrets" do
+    let(:attributes) { { "application" => "chrome" } }
+    let(:session_path) { "/org/freedesktop/secrets/session/121" }
+    let(:item) { "/org/freedesktop/secrets/collection/kdewallet/0" }
+    let(:prompt_path) { ["/org/freedesktop/secrets/prompt/p3"] }
+    let(:secret) { { item => [session_path, [], [116, 101, 115, 116], "text/plain"] } }
+
+    it "opens session and returns secrets for unlocked items" do
+      allow(service).to receive(:OpenSession).with("plain", []).and_return([[], session_path])
+      allow(service).to receive(:SearchItems).with(attributes).and_return([[item], []])
+      allow(service).to receive(:GetSecrets).with([item], session_path).and_return([secret])
+
+      expect(described_class.new.secrets(attributes)).to eq(["test"])
+    end
+
+    it "returns empty array when no unlocked items" do
+      allow(service).to receive(:OpenSession).with("plain", []).and_return([[], session_path])
+      allow(service).to receive(:SearchItems).with(attributes).and_return([[], []])
+      expect(service).not_to receive(:GetSecrets)
+
+      expect(described_class.new.secrets(attributes)).to eq([])
+    end
+
+    it "unlocks locked secrets" do
+      allow(service).to receive(:OpenSession).with("plain", []).and_return([[], session_path])
+      allow(service).to receive(:SearchItems).with(attributes).and_return([[], [item]])
+      allow(service).to receive(:Unlock).with([item]).and_return([[], prompt_path])
+
+      allow(secrets_service).to receive(:object).with(prompt_path).and_return(prompt_object)
+      allow(prompt_object).to receive(:[]).with(described_class::PROMPT_INTERFACE).and_return(prompt_interface)
+      allow(prompt_interface).to receive(:Prompt).with("").and_return(nil)
+
+      main_double = double("main")
+      allow(DBus::Main).to receive(:new).and_return(main_double)
+      allow(main_double).to receive(:<<).with(bus)
+      allow(main_double).to receive(:quit)
+      allow(main_double).to receive(:run)
+
+      # user cancels
+      cancel = true
+      allow(prompt_interface).to receive(:on_signal).with("Completed") do |&block|
+        block.call(cancel, cancel ? [] : [item])
+      end
+
+      allow(service).to receive(:GetSecrets).with([item], session_path).and_return([secret])
+
+      expect(described_class.new.secrets(attributes)).to eq([])
+
+      cancel = false
+      expect(described_class.new.secrets(attributes)).to eq(["test"])
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ module Helpers
       placeholders = (["?"] * row.size).join(", ")
       db.execute("INSERT INTO #{table_name} VALUES (#{placeholders})", row)
     end
+    yield(db) if block_given?
     path
   ensure
     db&.close


### PR DESCRIPTION
Currently there are 2 issues for Chrome:
1. Chrome encrypts cookies
2. Cookie expire time is stored since Windows epoch (1601 year) and not as unix timestamp

This PR fixes both of these issues.

I tested that with these changes I can successfully decrypt Chromium (v151) cookies on KDE Plasma with both KWallet and KeePassXC. It also works with Electron apps (eg. Discord etc) aswell.

I haven't tested it with GNOME but I think it should work. I'll test that at some point in future.

Also note that Flatpak Chrome might use `v12`  `SecretPortalKeyProvider` for cookie encryption which I didn't implement. It's not trivial to implement that and also for me I couldn't get Chrome to use it (always falls back to v10 so decrypts without issues).